### PR TITLE
Support maximumLimit in pagination

### DIFF
--- a/src/Schema/Plugin/PaginationPlugin.php
+++ b/src/Schema/Plugin/PaginationPlugin.php
@@ -88,7 +88,7 @@ class PaginationPlugin implements FieldPlugin, SchemaUpdater
 
         $defaultLimit = $config['defaultLimit'] ?? $this->config()->get('default_limit');
         $connectionName = $config['connection'] ?? $plainType;
-        $max = $this->config()->get('max_limit');
+        $max = $config['maximumLimit'] ?? $this->config()->get('max_limit');
         $limit = min($defaultLimit, $max);
         $field->addArg('limit', "Int = $limit")
             ->addArg('offset', "Int = 0")


### PR DESCRIPTION
At the moment, you can only change the maximum limit in the overall settings. This enables support for the maximumLimit setting per model.